### PR TITLE
btmgmt_protocol: Fix unhandled exception when decoding EIRData

### DIFF
--- a/btsocket/btmgmt_protocol.py
+++ b/btsocket/btmgmt_protocol.py
@@ -194,7 +194,11 @@ class EIRData(DataField):
             data_type = data[pointer + 1]
             data_start = pointer + 2
             data_end = data_start + len_data - 1
-            self.value[ADType(data_type)] = data[data_start:data_end]
+            try:
+                self.value[ADType(data_type)] = data[data_start:data_end]
+            except ValueError as ex:
+                raise ValueError(f"EIRData.decode: Invalid ADType: 0x{data_type:02x}, "
+                                 f"data len: {len(data)}, data: {data[pointer:].hex(' ')}") from ex
             pointer += data[pointer] + 1
 
     def encode(self, value, width):
@@ -235,8 +239,14 @@ class Packet:
             for index in range(repeated):
                 class_ = getattr(current_module, param.bt_type)
                 data_type = class_()
-                data_type.decode(pkt[pointer:pointer + param.width])
-                self._add_to_value(param, data_type.value)
+                try:
+                    data_type.decode(pkt[pointer:pointer + param.width])
+                    self._add_to_value(param, data_type.value)
+                except ValueError as ex:
+                    logger.error(
+                        f"Packet.decode: failed to decode {param.name} as {param.bt_type}. "
+                        f"Offset: {pointer}, width: {param.width}, pkt: {pkt.hex(' ')}. Error: {ex}"
+                    )
                 pointer += param.width
         if pointer < len(pkt):
             # self.value['parameters'] = pkt[pointer:]


### PR DESCRIPTION
ValueError: 0 is not a valid ADType

This is to fix an unhandled exception when receiving unsupported / invalid ADType value (0 - in my case).

Discussed also in this reported issue: https://github.com/ukBaz/python-btsocket/issues/13

I am not sure about the error message complexity, but in a case it happens rarely, it could be helpful.

An error log example:

```
2025-06-19 19:28:05,465 [  ERROR] btsocket.btmgmt_protocol: Packet.decode: failed to decode eir_data as EIRData. Offset: 14, width: 65535, pkt: c1 ce 55 1c 5e 68 01 9c 00 00 00 00 1f 00 02 01 06 1b 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 02 f0 ff. Error: EIRData.decode: Invalid ADType: 0x00, data len: 31, data: 1b 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 02 f0 ff
```